### PR TITLE
chore: 不要なgit cloneコマンドを削除し、必要なライブラリのみインストールするように修正

### DIFF
--- a/section02-jsonplaceholder/notebook-colab.ipynb
+++ b/section02-jsonplaceholder/notebook-colab.ipynb
@@ -24,9 +24,7 @@
    },
    "outputs": [],
    "source": [
-    "!git clone https://github.com/Shiny-HKLab/GenerativeAIDevelopmentSeminarDocumentation.git\n",
-    "%cd GenerativeAIDevelopmentSeminarDocumentation/section02-jsonplaceholder\n",
-    "!pip install -r requirements.txt"
+    "!pip install requests"
    ]
   },
   {
@@ -438,6 +436,19 @@
    "metadata": {},
    "source": [
     "### Pydanticモデルでデータをスマートに扱おう！\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install pydantic"
    ]
   },
   {


### PR DESCRIPTION
不要なgit cloneコマンドを削除し、必要なライブラリrequestsとpydanticのみインストールするように修正しました。これにより、ノートブックの実行が簡素化され、依存関係の管理が容易になります。